### PR TITLE
feat: Enable cross-user typeahead navigation with public APIs and improved fuzzy matching

### DIFF
--- a/backend/routes/searchRoutes/searchRoutes.js
+++ b/backend/routes/searchRoutes/searchRoutes.js
@@ -1,10 +1,12 @@
 const express = require('express')
 const { PrismaClient } = require('@prisma/client')
 const { isAuthenticated } = require('../../middleware/middleware')
-const { AutocompleteSystem, buildTypeaheadIndex } = require('../../typeAhead/typeAhead.js')
+const { AutocompleteSystem, buildTypeaheadIndex, levenshteinDistance } = require('../../typeAhead/typeAhead.js')
 
 const router = express.Router()
 const prisma = new PrismaClient()
+const GOOD_MATCH_SCORE = 60
+const FUZZY_MATCH_SCALE = 50
 
 // Initialize autocomplete system globally
 let autocompleteSystem = null
@@ -190,10 +192,13 @@ router.post('/api/search',isAuthenticated, async (req, res) => {
                id: subHub.id,
                type: 'subhub',
                title: subHub.name,
+               name: subHub.name,
                content: subHub.aiSummary,
                description: subHub.aiSummary,
                learningHub: subHub.learningHubId,
                chapterCount: subHub._count.chapters,
+               youtubeUrl: subHub.youtubeUrl,
+               category: subHub.category
            })),
            chapters: chapters.map(chapter => ({
                id: chapter.id,
@@ -232,7 +237,7 @@ router.post('/api/search',isAuthenticated, async (req, res) => {
 })
 
 // typeahead autocomplete with fuzzy search
-router.post('/api/typeahead', async (req, res) => {
+router.post('/api/typeahead', isAuthenticated, async (req, res) => {
     try {
         const {
             query,
@@ -255,13 +260,254 @@ router.post('/api/typeahead', async (req, res) => {
             autocompleteSystem.indexContent(indexData)
         }
 
-        // get suggestions
-        const suggestions = autocompleteSystem.search(query, {
+        // get suggestions from autocomplete system
+        const autocompleteSuggestions = autocompleteSystem.search(query, {
             maxResults,
             includeFuzzy,
             // dynamic threshold based on query length
             fuzzyThreshold: Math.min(3, Math.floor(query.length / 3))
         })
+
+       // Create enhanced search terms including autocomplete suggestions
+       const allSearchTerms = new Set([query.trim()])
+       autocompleteSuggestions.forEach(suggestion => allSearchTerms.add(suggestion))
+
+       // Get direct database matches for more comprehensive results
+       const searchTerm = query.trim()
+       const searchLimit = Math.min(maxResults, 10)
+
+       // Create fuzzy search patterns for better misspelling handling
+       const fuzzyPatterns = []
+
+       // Add all search terms (original query + autocomplete suggestions)
+       allSearchTerms.forEach(term => fuzzyPatterns.push(term))
+
+       // Add single character variations for common typos
+       if (searchTerm.length > 2) {
+           // Add patterns with single character deletions
+           for (let i = 0; i < searchTerm.length; i++) {
+               const pattern = searchTerm.slice(0, i) + searchTerm.slice(i + 1)
+               if (pattern.length > 1) fuzzyPatterns.push(pattern)
+           }
+
+           // Add patterns with single character substitutions (PS:: this is for common keyboard mistakes)
+           const keyboardMap = {
+               'a': ['s', 'q', 'w'], 'b': ['v', 'g', 'h', 'n'], 'c': ['x', 'd', 'f', 'v'],
+               'd': ['s', 'e', 'r', 'f', 'c'], 'e': ['w', 'r', 'd', 's'], 'f': ['d', 'r', 't', 'g', 'c', 'v'],
+               'g': ['f', 't', 'y', 'h', 'v', 'b'], 'h': ['g', 'y', 'u', 'j', 'b', 'n'], 'i': ['u', 'o', 'k', 'j'],
+               'j': ['h', 'u', 'i', 'k', 'n', 'm'], 'k': ['j', 'i', 'o', 'l', 'm'], 'l': ['k', 'o', 'p'],
+               'm': ['n', 'j', 'k'], 'n': ['b', 'h', 'j', 'm'], 'o': ['i', 'p', 'l', 'k'], 'p': ['o', 'l'],
+               'q': ['w', 'a'], 'r': ['e', 't', 'f', 'd'], 's': ['a', 'w', 'e', 'd', 'z', 'x'],
+               't': ['r', 'y', 'g', 'f'], 'u': ['y', 'i', 'j', 'h'], 'v': ['c', 'f', 'g', 'b'],
+               'w': ['q', 'e', 's', 'a'], 'x': ['z', 's', 'd', 'c'], 'y': ['t', 'u', 'h', 'g'],
+               'z': ['a', 's', 'x']
+           }
+
+           // PS:: Only add a few common substitution patterns to avoid too many queries
+           if (searchTerm.length <= 6) {
+               for (let i = 0; i < Math.min(2, searchTerm.length); i++) {
+                   const char = searchTerm[i].toLowerCase()
+                   if (keyboardMap[char]) {
+                       keyboardMap[char].slice(0, 2).forEach(replacement => {
+                           const pattern = searchTerm.slice(0, i) + replacement + searchTerm.slice(i + 1)
+                           fuzzyPatterns.push(pattern)
+                       })
+                   }
+               }
+           }
+       }
+
+       // Search SubHubs with fuzzy patterns
+       const subHubs = await prisma.subHub.findMany({
+           where: {
+               OR: fuzzyPatterns.flatMap(pattern => [
+                   { name: { contains: pattern, mode: 'insensitive' } },
+                   { aiSummary: { contains: pattern, mode: 'insensitive' } }
+               ])
+           },
+           take: searchLimit
+       })
+
+       // Search Chapters with fuzzy patterns
+       const chapters = await prisma.chapter.findMany({
+           where: {
+               OR: fuzzyPatterns.flatMap(pattern => [
+                   { title: { contains: pattern, mode: 'insensitive' } },
+                   { summary: { contains: pattern, mode: 'insensitive' } }
+               ])
+           },
+           include: {
+               subHub: {
+                   select: {
+                       id: true,
+                       name: true,
+                       youtubeUrl: true
+                   }
+               }
+           },
+           take: searchLimit
+       })
+
+       // Search Flashcards with fuzzy patterns
+       const flashcards = await prisma.flashCard.findMany({
+           where: {
+               OR: fuzzyPatterns.flatMap(pattern => [
+                   { question: { contains: pattern, mode: 'insensitive' } },
+                   { answer: { contains: pattern, mode: 'insensitive' } }
+               ])
+           },
+           include: {
+               subHub: {
+                   select: {
+                       id: true,
+                       name: true,
+                       youtubeUrl: true
+                   }
+               }
+           },
+           take: searchLimit
+       })
+
+
+       // Search Quizzes with fuzzy patterns
+       const quizzes = await prisma.quiz.findMany({
+           where: {
+               OR: fuzzyPatterns.flatMap(pattern => [
+                   { question: { contains: pattern, mode: 'insensitive' } },
+                   { answer: { contains: pattern, mode: 'insensitive' } }
+               ])
+           },
+           include: {
+               subHub: {
+                   select: {
+                       id: true,
+                       name: true,
+                       youtubeUrl: true
+                   }
+               }
+           },
+           take: searchLimit
+       })
+
+
+       // Search Posts with fuzzy patterns
+       const posts = await prisma.post.findMany({
+           where: {
+               OR: fuzzyPatterns.flatMap(pattern => [
+                   { title: { contains: pattern, mode: 'insensitive' } },
+                   { content: { contains: pattern, mode: 'insensitive' } }
+               ])
+           },
+           include: {
+               sharedSubHub: {
+                   select: {
+                       id: true,
+                       name: true,
+                       youtubeUrl: true
+                   }
+               }
+           },
+           take: searchLimit
+       })
+
+       // Helper function to calculate relevance score
+       const calculateScore = (text, query) => {
+           const lowerText = text.toLowerCase()
+           const lowerQuery = query.toLowerCase()
+
+           // Check if text matches any autocomplete suggestion (higher priority)
+           const isAutocompleteSuggestion = autocompleteSuggestions.some(suggestion =>
+               lowerText.includes(suggestion.toLowerCase())
+           )
+
+           // Exact match gets highest score
+           if (lowerText === lowerQuery) return isAutocompleteSuggestion ? 110 : 100
+
+           // Starts with query gets high score
+           if (lowerText.startsWith(lowerQuery)) return isAutocompleteSuggestion ? 100 : 90
+
+           // Contains query gets medium score
+           if (lowerText.includes(lowerQuery)) return isAutocompleteSuggestion ? 85 : 70
+
+           // Check if text contains any autocomplete suggestion
+           for (const suggestion of autocompleteSuggestions) {
+               if (lowerText.includes(suggestion.toLowerCase())) {
+                   return GOOD_MATCH_SCORE
+               }
+           }
+
+           // Calculate character distance for fuzzy matches
+           const distance = levenshteinDistance(lowerQuery, lowerText)
+           const maxLength = Math.max(lowerQuery.length, lowerText.length)
+           const similarity = 1 - (distance / maxLength)
+
+           return Math.floor(similarity * FUZZY_MATCH_SCALE)
+       }
+
+       // Format suggestions with scoring
+       const suggestions = [
+           ...subHubs.map(subHub => ({
+               id: subHub.id,
+               type: 'subhub',
+               title: subHub.name,
+               name: subHub.name,
+               youtubeUrl: subHub.youtubeUrl,
+               category: subHub.category,
+               score: Math.max(
+                   calculateScore(subHub.name, searchTerm),
+                   subHub.aiSummary ? calculateScore(subHub.aiSummary, searchTerm) : 0
+               )
+           })),
+           ...chapters.map(chapter => ({
+               id: chapter.id,
+               type: 'chapter',
+               title: `${chapter.title} (${chapter.subHub?.name || 'Unknown SubHub'})`,
+               name: chapter.title,
+               subHub: chapter.subHub,
+               score: Math.max(
+                   calculateScore(chapter.title, searchTerm),
+                   chapter.summary ? calculateScore(chapter.summary, searchTerm) : 0
+               )
+           })),
+           ...flashcards.map(flashcard => ({
+               id: flashcard.id,
+               type: 'flashcard',
+               title: `Flashcard: ${flashcard.question.substring(0, 40)}... (${flashcard.subHub?.name || 'Unknown SubHub'})`,
+               name: flashcard.question,
+               subHub: flashcard.subHub,
+               score: Math.max(
+                   calculateScore(flashcard.question, searchTerm),
+                   calculateScore(flashcard.answer, searchTerm)
+               )
+           })),
+           ...quizzes.map(quiz => ({
+               id: quiz.id,
+               type: 'quiz',
+               title: `Quiz: ${quiz.question.substring(0, 40)}... (${quiz.subHub?.name || 'Unknown SubHub'})`,
+               name: quiz.question,
+               subHub: quiz.subHub,
+               score: Math.max(
+                   calculateScore(quiz.question, searchTerm),
+                   calculateScore(quiz.answer, searchTerm)
+               )
+           })),
+           ...posts.map(post => ({
+               id: post.id,
+               type: 'post',
+               title: post.title,
+               name: post.title,
+               subHub: post.sharedSubHub,
+               score: Math.max(
+                   calculateScore(post.title, searchTerm),
+                   post.content ? calculateScore(post.content, searchTerm) : 0
+               )
+           }))
+       ]
+       // Sort by score descending
+       .sort((a, b) => b.score - a.score)
+       .slice(0, maxResults)
+       // Remove score from final result
+       .map(({ score, ...item }) => item)
 
         res.json({
             query,

--- a/backend/typeAhead/typeAhead.js
+++ b/backend/typeAhead/typeAhead.js
@@ -229,5 +229,6 @@ const buildTypeaheadIndex = async () => {
 
 module.exports = {
     buildTypeaheadIndex,
-    AutocompleteSystem
+    AutocompleteSystem,
+    levenshteinDistance
 }


### PR DESCRIPTION
# Description  
- What does this PR do?  
  `Implements comprehensive cross-user content access for typeahead search by adding public API endpoints and enhancing search
  functionality with advanced fuzzy matching`
- Why is it necessary or valuable?  
  `Solves the critical issue where users could see other users' content in typeahead suggestions but couldn't actually access it due to
  user-restricted APIs. Enables true content discovery across the platform while maintaining security boundaries` 
- What is intentionally left out and will be done in a later PR?  
  `Search result caching, search analytics, and potential refactoring to eliminate code duplication between search and typeahead
  endpoints`
`PS:: Code duplication will be refactored`

---

# Milestones / Related Work  
- Feature or user story this contributes to: `Typeahead search with cross-user content discovery`  
- Milestone or version target: `TypeAhead Feature Complete v2.0`  

---

# Resources and References  
- Tutorials, documentation, or code examples used:  
  `QWERTY keyboard layout mapping for realistic typo patterns`  
- Any copied or adapted code (with attribution):  
  `<Mention if any logic was reused or adapted>`  
- Internal references (Figma, Notion, Slack threads):  
  `<Optional: add internal planning/resource links>`

---

## Edge Cases Tested  
 - `Non-existent subhub IDs return proper 404 errors`
  - `Empty content arrays return appropriate empty responses`
  - `Authentication still required for all public endpoints`
  - `Misspelled queries with 1-2 character errors find correct content`
  - `Mixed case and special characters in search terms`

---
  ## Key Changes Made

  ### flashcardRoutes.js
  - Added `GET /api/flashcards/:subHubId/public` endpoint for cross-user flashcard access
  - Fixed database field name from `flashCards` to `flashCard` (singular) to match schema
  - Returns flashcards in same format as private API for frontend compatibility

  ### quizRoutes.js
  - Added `GET /api/quizzes/:subHubId/public` endpoint for cross-user quiz access
  - Fixed database field name from `quizzes` to `quiz` (singular) to match schema
  - Organizes quizzes by difficulty levels (easy/medium/hard) matching private API format

  ### subHubRoutes.js
  - Added `GET /api/subhub/:subHubId/public` endpoint for basic subhub info access
  - Added `GET /api/subhub/:subHubId/chapters/public` endpoint for cross-user chapter access
  - All public endpoints require authentication but don't restrict by user ownership

  ### searchRoutes.js
  - Enhanced fuzzy search with keyboard-aware typo patterns and character deletion patterns
  - Integrated existing autocomplete system suggestions into database search terms
  - Added relevance scoring system prioritizing exact matches > prefix matches > fuzzy matches
  - Enhanced suggestion titles to include subhub context: "Chapter Name (SubHub Name)"
  - Added Levenshtein distance-based scoring for fuzzy match quality
  - Maintained response format compatibility with existing frontend components
---

# Additional Notes  
- Known limitations: `Both search and typeahead endpoints share ~90% identical code which needs to be refactored into a shared service`  
- Planned follow-up PRs: `Refactor search logic into shared service, implement search result caching`  
- Reviewer requests or feedback needed: `Please verify the fuzzy search patterns don't generate too many database queries and review the
  scoring algorithm for search relevance`