### PR TITLE
feat: implement thumbnails attached to a created post

### DIFF
--- a/backend/prisma/migrations/20250722225046_post_thumbnail/migration.sql
+++ b/backend/prisma/migrations/20250722225046_post_thumbnail/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "thumbnail" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -49,6 +49,7 @@ model Post {
     content String
     createdAt DateTime @default(now())
     like Int @default(0)
+    thumbnail String?
     user User @relation(fields: [userId], references: [id])
     userId String
     comment PostComment []

--- a/backend/routes/postRoutes/postRoutes.js
+++ b/backend/routes/postRoutes/postRoutes.js
@@ -3,6 +3,9 @@ const { Router } = express
 const { PrismaClient } = require("@prisma/client")
 const { isAuthenticated } = require("../../middleware/middleware.js")
 const fetch = require("../../utils/fetch.js")
+const { extractThumbnailFromUrl } = require("../../utils/youtubeThumbnail.js")
+const topKRecommendations = require("../../recommendationAlgo/recommendation")
+
 const prisma = new PrismaClient()
 const router = Router()
 
@@ -104,12 +107,25 @@ router.post("/api/posts", isAuthenticated, async (req, res) => {
         const { title, content, sharedSubHubId } = req.body
         const userId = req.user.id
 
+       // Get thumbnail from shared SubHub if available
+       let thumbnail = null
+       if (sharedSubHubId) {
+           const sharedSubHub = await prisma.subHub.findUnique({
+               where: { id: parseInt(sharedSubHubId) },
+               select: { youtubeUrl: true }
+           })
+           if (sharedSubHub && sharedSubHub.youtubeUrl) {
+               thumbnail = extractThumbnailFromUrl(sharedSubHub.youtubeUrl, 'hqdefault')
+           }
+       }
+
         const newPost = await prisma.post.create({
             data: {
                 title,
                 content,
                 userId,
-                sharedSubHubId: sharedSubHubId || null
+                sharedSubHubId: sharedSubHubId || null,
+                thumbnail: thumbnail
             },
             include: {
                 user: {
@@ -357,13 +373,15 @@ router.post("/api/posts/share-subhub", isAuthenticated, async (req, res) => {
                postContent = `Just completed "${subHub.name}" - incredible learning journey! 🧠 Can't wait to apply these insights! #Learning #Growth`
            }
        }
-
+       // Extract thumbnail from YouTube URL
+       const thumbnail = subHub.youtubeUrl ? extractThumbnailFromUrl(subHub.youtubeUrl, 'hqdefault') : null
        const sharedPost = await prisma.post.create({
            data: {
                title: postTitle,
                content: postContent,
                userId,
-               sharedSubHubId: parseInt(subHubId)
+               sharedSubHubId: parseInt(subHubId),
+               thumbnail
            },
            include: {
                user: {
@@ -403,7 +421,6 @@ router.post("/api/posts/share-subhub", isAuthenticated, async (req, res) => {
 router.get("/api/posts/recommendations", isAuthenticated, async (req, res) => {
    try {
        const userId = req.user.id
-       const topKRecommendations = require("../../recommendationAlgo/recommendation")
 
        // Get user's following list for enhanced recommendations
        const followingUsers = await prisma.user.findUnique({

--- a/backend/routes/postRoutes/postRoutes.js
+++ b/backend/routes/postRoutes/postRoutes.js
@@ -379,9 +379,9 @@ router.post("/api/posts/share-subhub", isAuthenticated, async (req, res) => {
            data: {
                title: postTitle,
                content: postContent,
-               userId,
+               userId: userId,
                sharedSubHubId: parseInt(subHubId),
-               thumbnail
+               thumbnail: thumbnail
            },
            include: {
                user: {

--- a/backend/typeAhead/typeAhead.js
+++ b/backend/typeAhead/typeAhead.js
@@ -26,8 +26,7 @@ class Trie {
                 curr.children[c] = new TrieNode()
             }
             curr = curr.children[c]
-            // curr.words.push(word)
-
+            
             const currFreq = curr.words.get(lowerWord) || 0
             curr.words.set(lowerWord, currFreq + frequency)
         }

--- a/backend/utils/youtubeThumbnail.js
+++ b/backend/utils/youtubeThumbnail.js
@@ -1,0 +1,70 @@
+// Utility functions for extracting YouTube video thumbnails
+
+// Extract video ID from various YouTube URL formats
+function extractVideoId(url) {
+   if (!url) return null
+
+   const patterns = [
+       // Standard youtube.com URLs
+       /(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?v=([a-zA-Z0-9_-]+)/,
+       // Shortened youtu.be URLs
+       /(?:https?:\/\/)?youtu\.be\/([a-zA-Z0-9_-]+)/,
+       // YouTube embed URLs
+       /(?:https?:\/\/)?(?:www\.)?youtube\.com\/embed\/([a-zA-Z0-9_-]+)/,
+       // YouTube playlist URLs with video
+       /(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?v=([a-zA-Z0-9_-]+)&list=/,
+       // YouTube URLs with additional parameters
+       /(?:https?:\/\/)?(?:www\.)?youtube\.com\/watch\?.*v=([a-zA-Z0-9_-]+)/
+   ]
+
+   for (const pattern of patterns) {
+       const match = url.match(pattern)
+       if (match && match[1]) {
+           return match[1]
+       }
+   }
+
+   return null
+}
+
+// quality - Thumbnail quality (default(120x90), hqdefault(480x360), mqdefault(320x180), sddefault(640x480), maxresdefault(1280x720))
+function getThumbnailUrl(videoId, quality = 'hqdefault') {
+   if (!videoId) return null
+
+   // YouTube thumbnail URL format
+   return `https://img.youtube.com/vi/${videoId}/${quality}.jpg`
+}
+
+function extractThumbnailFromUrl(youtubeUrl, quality = 'hqdefault') {
+   const videoId = extractVideoId(youtubeUrl)
+   if (!videoId) return null
+
+   return getThumbnailUrl(videoId, quality)
+}
+
+// Get multiple thumbnail qualities for a YouTube URL
+function getAllThumbnailQualities(youtubeUrl) {
+   const videoId = extractVideoId(youtubeUrl)
+   if (!videoId) return null
+
+   return {
+       default: getThumbnailUrl(videoId, 'default'),
+       medium: getThumbnailUrl(videoId, 'mqdefault'),
+       high: getThumbnailUrl(videoId, 'hqdefault'),
+       standard: getThumbnailUrl(videoId, 'sddefault'),
+       maxres: getThumbnailUrl(videoId, 'maxresdefault')
+   }
+}
+
+// Validate if URL is a valid YouTube URL
+function isValidYouTubeUrl(url) {
+   return extractVideoId(url) !== null
+}
+
+module.exports = {
+   extractVideoId,
+   getThumbnailUrl,
+   extractThumbnailFromUrl,
+   getAllThumbnailQualities,
+   isValidYouTubeUrl
+}

--- a/frontend/src/components/Community/PostFeed/PostFeed.jsx
+++ b/frontend/src/components/Community/PostFeed/PostFeed.jsx
@@ -49,15 +49,17 @@ const UserList = ({ users, onFollow, feedType }) => {
 export const PostFeed = () => {
     const [posts, setPosts] = useState([])
     const [users, setUsers] = useState([])
-   const [loading, setLoading] = useState(false)
+    const [loading, setLoading] = useState(false)
     const [feedType, setFeedType] = useState('for-you')
-   const [currentPage, setCurrentPage] = useState(1)
-   const [pagination, setPagination] = useState({
-       totalPages: 1,
-       currentPage: 1,
-       hasPrev: false,
-       hasNext: false
-   })
+    const [currentPage, setCurrentPage] = useState(1)
+    const [pagination, setPagination] = useState({
+        totalPages: 1,
+        currentPage: 1,
+        hasPrev: false,
+        hasNext: false
+    })
+    const [searchRequestId, setSearchRequestId] = useState(0)
+
 
    useEffect(() => {
         if (feedType === 'for-you' || feedType === 'posts') {
@@ -141,20 +143,19 @@ export const PostFeed = () => {
     const handleComment = async (postId, commentText) => {
         try {
             const newComment = await commentOnPost(postId, commentText)
-
             setPosts(posts.map(post => {
-                if (post.id === postId) {
-                    return {
-                        ...post,
-                        comment: [...(post.comment || []), newComment]
-                    }
-                }
-                return post
-            }))
-        } catch (error) {
-            // Error handled silently
-        }
-    }
+               if (post.id === postId) {
+                   return {
+                       ...post,
+                       comment: [...(post.comment || []), newComment]
+                   }
+               }
+               return post
+           }))
+       } catch (error) {
+           // Error handled silently
+       }
+   }
 
     const handleFollow = async (userId, isCurrentlyFollowing) => {
         try {
@@ -171,16 +172,24 @@ export const PostFeed = () => {
     }
 
     const handleSearch = async (term) => {
-        if (!term || !term.trim()) return
+       if (!term || !term.trim()) return
 
-        try {
-            const searchResults = await searchContent(term)
-            setPosts(searchResults.posts || [])
-            setFeedType('search')
-        } catch (error) {
-            setPosts([])
-        }
-    }
+       const currentRequestId = searchRequestId + 1
+       setSearchRequestId(currentRequestId)
+
+       try {
+           const searchResults = await searchContent(term)
+
+           if (currentRequestId === searchRequestId) {
+               setPosts(searchResults.posts || [])
+               setFeedType('search')
+           }
+       } catch (error) {
+           if (currentRequestId === searchRequestId) {
+               setPosts([])
+           }
+       }
+   }
 
 
   if (loading) {

--- a/frontend/src/components/Hub/SubHubCard.jsx
+++ b/frontend/src/components/Hub/SubHubCard.jsx
@@ -12,9 +12,15 @@ export const SubHubCard = (props) => {
 
     if (isSharing) return
 
-    setIsSharing(true)
+
+   setIsSharing(true)
+
+   // Ensure minimum display time of 1.5 seconds for better UX
+   const startTime = Date.now()
+   const minDisplayTime = 1500 // 1.5 seconds
+
     try {
-      // Let the backend generate smart content from chapters
+      // backend generate smart content from chapters
       await shareSubHub(props.id)
 
       // Show success feedback
@@ -22,11 +28,17 @@ export const SubHubCard = (props) => {
         props.onShare()
       }
     } catch (error) {
-      // Error handling could be improved with a toast notification system
+      // throw new Error("Failed to share subhub")
     } finally {
-      setIsSharing(false)
-    }
-  }
+      // shows the "Sharing..." text for at least the minimum time
+      const elapsed = Date.now() - startTime
+      const remainingTime = Math.max(0, minDisplayTime - elapsed)
+
+      setTimeout(() => {
+        setIsSharing(false)
+      }, remainingTime)
+   }
+ }
 
   const handleDelete = async (e) => {
     e.preventDefault()
@@ -41,7 +53,7 @@ export const SubHubCard = (props) => {
       throw new Error("Failed to delete subhub")
     }
   }
-  
+
   return (
     <div className="subhub-card">
       <Link

--- a/frontend/src/components/TypeAheadSearchbar/TypeAheadSearchbar.jsx
+++ b/frontend/src/components/TypeAheadSearchbar/TypeAheadSearchbar.jsx
@@ -13,6 +13,7 @@ export const TypeAheadSearchbar = ({ onSearch }) => {
    const debounceRef = useRef(null)
    const dropdownRef = useRef(null)
    const navigate = useNavigate()
+   const requestIdRef = useRef(0)
 
    const handleSubmit = (e) => {
        e.preventDefault()
@@ -42,19 +43,28 @@ export const TypeAheadSearchbar = ({ onSearch }) => {
           return
       }
 
+      const currentRequestId = ++requestIdRef.current
       setLoading(true)
       try {
           const results = await getTypeaheadSuggestions(query)
-          setSuggestions(results.suggestions || [])
-          setShowDropdown(true)
-          setSelectedIndex(-1)
+
+          if (currentRequestId === requestIdRef.current) {
+              setSuggestions(results.suggestions || [])
+              setShowDropdown(true)
+              setSelectedIndex(-1)
+          }
       } catch (error) {
-          setSuggestions([])
-          setShowDropdown(false)
+          if (currentRequestId === requestIdRef.current) {
+              setSuggestions([])
+              setShowDropdown(false)
+          }
       } finally {
-          setLoading(false)
+          if (currentRequestId === requestIdRef.current) {
+              setLoading(false)
+          }
       }
   }
+
 
   const handleInputChange = (e) => {
       const value = e.target.value


### PR DESCRIPTION
# Description  
- What does this PR do?  
  `This PR implements thumbnail generation and display for post cards in the community feed. It extracts thumbnails from YouTube URLs associated with shared SubHubs and displays them within post cards.`  
- Why is it necessary or valuable?  
  `This enhancement provides visual context for shared learning content, making posts more engaging and informative. Users can now quickly identify video content without needing to click through to the SubHub.`  

---

# Milestones / Related Work  
- Feature or user story this contributes to: `User's post should include a thumbnail`  

---

# Resources and References  
- Tutorials, documentation, or code examples used:  
  [YouTube Data API documentation for thumbnail formats](https://developers.google.com/youtube/v3/docs/thumbnails)

---

# Test Plan  
- How was this tested?  
  `Manual testing with various YouTube URL formats, verified thumbnail rendering across different post types and screen sizes`  
- Screenshots or recordings:  
  [loom video](https://www.loom.com/share/3b5a111d8a6642aeb5e23fdfe0660129?sid=48314ed0-4cfb-41e6-acd6-8b9a3dae1c31)
## Edge Cases Tested  
- `Invalid YouTube URLs (graceful fallback to no thumbnail)`
-  `Different thumbnail qualities and aspect ratios`

